### PR TITLE
use american english for pipeline definition

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -23,7 +23,7 @@ ingress-default-backend:
     release:
       traits:
         version:
-          preprocess: 'finalise'
+          preprocess: 'finalize'
         release:
           nextversion: 'bump_minor'
         component_descriptor: ~


### PR DESCRIPTION
Users expect to write american english in pipeline definitions.
Therefore rename "finalise" to "finalize"