### PR TITLE
Set absolute path for the gardener logo on the 404 page

### DIFF
--- a/views/index.pug
+++ b/views/index.pug
@@ -5,6 +5,6 @@ block content
     h1.jumbotron-heading Ingress Default Backend
     h4 404 Not Found
     p
-      img(src='img/gardener-large.png')
+      img(src='/img/gardener-large.png')
     p.lead.text-muted
       Shoot Shoot Kubernetes cluster provided by #[a(href='https://github.com/gardener/gardener') Gardener].


### PR DESCRIPTION
For cases, when 404 url is served within subpath, e.g. `/404/404`