### PR TITLE
make health endpoint configurable

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,6 +22,7 @@ const bodyParser = require('body-parser');
 const app = module.exports = express();
 const index = require('./routes/index');
 const healthy = require('./routes/healthy');
+const health_endpoint = process.env.HEALTH_ENDPOINT || '/healthy';
 
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'pug');
@@ -33,7 +34,7 @@ app.use(bodyParser.urlencoded({
 app.use(bodyParser.json());
 
 // routes
-app.use('/healthy', healthy);
+app.use(health_endpoint, healthy);
 app.use('*', index);
 
 // error handler


### PR DESCRIPTION
**What this PR does / why we need it**:

With commit https://github.com/gardener/ingress-default-backend/commit/9531d41feabffe8da5981f76829f988bcc70eee2, the health endpoint has been changed to `/healthy`. This has the disadvantage that it blocks the 'easy way' of deploying the default backend by simply configuring it in the nginx chart, since the health endpoint is not configurable there (see [here](https://github.com/kubernetes/ingress-nginx/blob/master/charts/ingress-nginx/templates/default-backend-deployment.yaml#L69)).

By making the health endpoint configurable via an env var, the original reason for changing the endpoint is honored while it is now possible to also deploy the backend via the nginx chart.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The health endpoint is now configurable by setting the env var `HEALTH_ENDPOINT`. The default (`/healthy`) has not been changed.
```
