### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,7 +1,5 @@
 ingress-default-backend:
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess:
@@ -16,7 +14,6 @@ ingress-default-backend:
             inputs:
               repos:
                 source: ~ # default
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ingress-default-backend'
     steps: ~
   jobs:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -4,6 +4,8 @@ ingress-default-backend:
       version:
         preprocess:
           'inject-commit-hash'
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         oci-builder: docker-buildx
         platforms:
@@ -14,8 +16,7 @@ ingress-default-backend:
             inputs:
               repos:
                 source: ~ # default
-            image: 'eu.gcr.io/gardener-project/gardener/ingress-default-backend'
-    steps: ~
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/ingress-default-backend
   jobs:
     head-update: ~
     pull-request:
@@ -25,6 +26,11 @@ ingress-default-backend:
       traits:
         version:
           preprocess: 'finalize'
+        publish:
+          dockerimages:
+            ingress-default-backend:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/ingress-default-backend
         release:
           nextversion: 'bump_minor'
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 PROJECT          := ingress-default-backend
 VERSION          := $(shell cat VERSION)
-REGISTRY         := eu.gcr.io/gardener-project/gardener
+REGISTRY         := europe-docker.pkg.dev/gardener-project/public/gardener
 IMAGE_REPOSITORY := $(REGISTRY)/$(PROJECT)
 IMAGE_TAG        := $(VERSION)
 


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
