### PR TITLE
Ignore rc version of golang

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,3 +5,10 @@ updates:
   directory: /
   schedule:
     interval: daily
+  allowed-updates:
+    - match:
+        dependency-name: "golang"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+  ignore:
+    - dependency-name: "golang"
+      versions: ["*-rc*"]


### PR DESCRIPTION
**What this PR does / why we need it**:

Ignore rc version of golang in dependabot configuration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
