### PR TITLE
Introduce `gosec` for Static Application Security Testing (SAST)

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -17,6 +17,9 @@ ingress-default-backend:
               repos:
                 source: ~ # default
             image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/ingress-default-backend
+    steps:
+      verify:
+        image: golang:1.23.4
   jobs:
     head-update: ~
     pull-request:

--- a/.ci/verify
+++ b/.ci/verify
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cd "$(dirname $0)/.."
+
+git config --global user.email "gardener@sap.com"
+git config --global user.name "Gardener CI/CD"
+
+make verify

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 bin
+/hack/tools/bin
 .kube-secrets
+.idea
+
+# gosec
+gosec-report.sarif

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,23 @@ PATH             := $(GOBIN):$(PATH)
 
 export PATH
 
+TOOLS_DIR := hack/tools
+include $(TOOLS_DIR)/tools.mk
+
 ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
 	EFFECTIVE_VERSION := $(EFFECTIVE_VERSION)-dirty
 endif
+
+.PHONY: sast
+sast: $(GOSEC)
+	@./hack/sast.sh
+
+.PHONY: sast-report
+sast-report: $(GOSEC)
+	@./hack/sast.sh --gosec-report true
+
+.PHONY: verify
+verify: sast-report
 
 .PHONY: install
 install:

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+report_dir="$(git rev-parse --show-toplevel)"
+
+gosec_report="false"
+gosec_report_parse_flags=""
+exclude_dirs="hack"
+
+parse_flags() {
+  while test $# -gt 1; do
+    case "$1" in
+      --gosec-report)
+        shift; gosec_report="$1"
+        ;;
+      --report-dir)
+        shift; report_dir="$1"
+        ;;
+      --exclude-dirs)
+        shift; exclude_dirs="$1"
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
+
+parse_flags "$@"
+
+echo "> Running gosec"
+gosec --version
+if [[ "$gosec_report" != "false" ]]; then
+  echo "Exporting report to ${report_dir}/gosec-report.sarif"
+  gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=${report_dir}/gosec-report.sarif -stdout"
+fi
+
+# Gardener uses code-generators https://github.com/kubernetes/code-generator and https://github.com/protocolbuffers/protobuf
+# which create lots of G103 (CWE-242: Use of unsafe calls should be audited) & G104 (CWE-703: Errors unhandled) errors.
+# However, those generators are best-pratice in Kubernetes environment and their results are tested well.
+# Thus, generated code is excluded from gosec scan.
+# Nested go modules are not supported by gosec (see https://github.com/securego/gosec/issues/501), so the ./hack folder
+# is excluded too. It does not contain productive code anyway.
+gosec -exclude-generated $(echo "$exclude_dirs" | awk -v RS=',' '{printf "-exclude-dir %s ", $1}') $gosec_report_parse_flags ./...

--- a/hack/tools/install-gosec.sh
+++ b/hack/tools/install-gosec.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+echo "> Installing gosec"
+
+TOOLS_BIN_DIR=${TOOLS_BIN_DIR:-$(dirname $0)/bin}
+
+platform=$(uname -s | tr '[:upper:]' '[:lower:]')
+version=$GOSEC_VERSION
+case $(uname -m) in
+  aarch64 | arm64)
+    arch="arm64"
+    ;;
+  x86_64)
+    arch="amd64"
+    ;;
+  *)
+    echo "Unknown architecture"
+    exit -1
+    ;;
+esac
+
+archive_name="gosec_${version#v}_${platform}_${arch}"
+file_name="${archive_name}.tar.gz"
+
+temp_dir="$(mktemp -d)"
+function cleanup {
+  rm -rf "${temp_dir}"
+}
+trap cleanup EXIT ERR INT TERM
+
+curl -L -o ${temp_dir}/${file_name} "https://github.com/securego/gosec/releases/download/${version}/${file_name}"
+
+tar -xzm -C "${temp_dir}" -f "${temp_dir}/${file_name}"
+mv "${temp_dir}/gosec" $TOOLS_BIN_DIR
+chmod +x $TOOLS_BIN_DIR/gosec

--- a/hack/tools/tools.mk
+++ b/hack/tools/tools.mk
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+TOOLS_BIN_DIR              := $(TOOLS_DIR)/bin
+GOSEC                      := $(TOOLS_BIN_DIR)/gosec
+
+export PATH := $(abspath $(TOOLS_BIN_DIR)):$(PATH)
+
+#########################################
+# Common                                #
+#########################################
+# Tool targets should declare go.mod as a prerequisite, if the tool's version is managed via go modules. This causes
+# make to rebuild the tool in the desired version, when go.mod is changed.
+# For tools where the version is not managed via go.mod, we use a file per tool and version as an indicator for make
+# whether we need to install the tool or a different version of the tool (make doesn't rerun the rule if the rule is
+# changed).
+# Use this "function" to add the version file as a prerequisite for the tool target: e.g.
+#   $(HELM): $(call tool_version_file,$(HELM),$(HELM_VERSION))
+tool_version_file = $(TOOLS_BIN_DIR)/.version_$(subst $(TOOLS_BIN_DIR)/,,$(1))_$(2)
+# Use this function to get the version of a go module from go.mod
+version_gomod = $(shell go list -mod=mod -f '{{ .Version }}' -m $(1))
+# This target cleans up any previous version files for the given tool and creates the given version file.
+# This way, we can generically determine, which version was installed without calling each and every binary explicitly.
+$(TOOLS_BIN_DIR)/.version_%:
+	@version_file=$@; rm -f $${version_file%_*}*
+	@touch $@
+.PHONY: clean-tools-bin
+clean-tools-bin:
+	rm -rf $(TOOLS_BIN_DIR)/*
+
+# default tool versions
+# renovate: datasource=github-releases depName=securego/gosec
+GOSEC_VERSION ?= v2.20.0
+
+$(GOSEC): $(call tool_version_file,$(GOSEC),$(GOSEC_VERSION))
+	@GOSEC_VERSION=$(GOSEC_VERSION) $(TOOLS_DIR)/install-gosec.sh

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/gorilla/mux"
 )
@@ -38,8 +39,9 @@ func main() {
 	router.NotFoundHandler = http.HandlerFunc(notFoundHandler)
 
 	server := &http.Server{
-		Addr:    ":" + port,
-		Handler: router,
+		Addr:              ":" + port,
+		Handler:           router,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	fmt.Printf("Kubernetes backend started on port %s...\n", port)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces `gosec` for Static Application Security Testing at Gardener and should replace other code scanners.

It uses the default ruleset of `gosec` similar to what was introduced to gardener/gardener in https://github.com/gardener/gardener/pull/9959.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
`gosec` was introduced for Static Application Security Testing (SAST).
```
