### PR TITLE
Add write permission for build

### DIFF
--- a/.github/workflows/head-update.yaml
+++ b/.github/workflows/head-update.yaml
@@ -9,6 +9,10 @@ jobs:
     with:
       mode: snapshot
     secrets: inherit
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
 
   component-descriptor:
     uses: gardener/cc-utils/.github/workflows/post-build.yaml@master


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently build job fails with the following error - 

```
The workflow is not valid. .github/workflows/head-update.yaml (Line: 7, Col: 3): Error calling workflow 'gardener/ingress-default-backend/.github/workflows/build.yaml@07cf01d47744973375550c03c485a1436109bbbf'. The nested job 'oci-images' is requesting 'packages: write, id-token: write', but is only allowed 'packages: read, id-token: none'.
```

/cc @ccwienk 
/cc @kon-angelo builds are failing on PRs in `provider-aws` and possibly many others for the same reason.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
